### PR TITLE
fix: "全屏”按钮状态错误以及返回按钮偶尔会消失

### DIFF
--- a/ZFPlayer/CustomPlayerControlView.m
+++ b/ZFPlayer/CustomPlayerControlView.m
@@ -235,13 +235,14 @@ static const CGFloat ZFPlayerControlBarAutoFadeOutTimeInterval = 0.35f;
     }];
     
     [self.fullScreenBtn mas_makeConstraints:^(MASConstraintMaker *make) {
-        make.width.height.mas_equalTo(20);
-        make.trailing.equalTo(self.bottomImageView.mas_trailing).offset(-15);
+        make.height.mas_equalTo(40);
+        make.width.mas_equalTo(30);
+        make.trailing.equalTo(self.bottomImageView.mas_trailing);
         make.centerY.equalTo(self.bottomImageView);
     }];
 
     [self.totalTimeLabel mas_makeConstraints:^(MASConstraintMaker *make) {
-        make.trailing.equalTo(self.fullScreenBtn.mas_leading).offset(-15);
+        make.trailing.equalTo(self.fullScreenBtn.mas_leading).offset(0);
         make.centerY.equalTo(self.bottomImageView);
         make.width.mas_equalTo(43);
     }];

--- a/ZFPlayer/CustomPlayerControlView.m
+++ b/ZFPlayer/CustomPlayerControlView.m
@@ -378,6 +378,8 @@ static const CGFloat ZFPlayerControlBarAutoFadeOutTimeInterval = 0.35f;
 
 - (void)backBtnClick:(UIButton *)sender {
     sender.hidden = YES;
+    self.fullScreen = NO;
+    self.fullScreenBtn.selected = NO;
     if ([self.zfDelegate respondsToSelector:@selector(zf_controlView:fullScreenAction:)]) {
         [self.zfDelegate zf_controlView:self fullScreenAction:sender];
     }
@@ -408,6 +410,8 @@ static const CGFloat ZFPlayerControlBarAutoFadeOutTimeInterval = 0.35f;
 - (void)fullScreenBtnClick:(UIButton *)sender {
     sender.selected = !sender.selected;
     self.fullScreen = sender.selected;
+    self.backBtn.hidden = !self.fullScreen;
+    self.topImageView.hidden = !self.fullScreen;
     if ([self.zfDelegate respondsToSelector:@selector(zf_controlView:fullScreenAction:)]) {
         [self.zfDelegate zf_controlView:self fullScreenAction:sender];
     }
@@ -539,7 +543,7 @@ static const CGFloat ZFPlayerControlBarAutoFadeOutTimeInterval = 0.35f;
 - (void)setOrientationPortraitConstraint {
     // 如果现在是小屏幕就不显示返回按钮,反之就显示
     self.backBtn.hidden = ![self currentIsFullScreen];
-
+    NSLog([NSString stringWithFormat:@"setOrientationPortraitConstraint %d", self.backBtn.isHidden]);
     [self.backBtn mas_remakeConstraints:^(MASConstraintMaker *make) {
         make.top.equalTo(self.topImageView.mas_top).offset(3);
         make.leading.equalTo(self.topImageView.mas_leading).offset(10);
@@ -563,6 +567,8 @@ static const CGFloat ZFPlayerControlBarAutoFadeOutTimeInterval = 0.35f;
         self.shrink                = NO;
     }
     ZFPlayerShared.isStatusBarHidden = NO;
+    self.topImageView.hidden = !self.fullScreen;
+    self.backBtn.hidden = !self.fullScreen;
 }
 
 - (void)hideControlView {
@@ -1129,6 +1135,7 @@ static const CGFloat ZFPlayerControlBarAutoFadeOutTimeInterval = 0.35f;
         self.topImageView.hidden = YES;
         self.backBtn.hidden = YES;
     }
+    NSLog([NSString stringWithFormat:@"zf_playerPlayEnd - %d", self.backBtn.isHidden]);
     // 隐藏controlView
     [self hideControlView];
     self.backgroundColor  = RGBA(0, 0, 0, .3);


### PR DESCRIPTION
fix: 从播放页面不通过“全屏”按钮返回到小窗口播放会导致“全屏”按钮状态错误以及返回按钮偶尔会消失
style: 优化全屏按钮的点击效果